### PR TITLE
add jsonカラム適応完了

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,11 @@
 class User < ApplicationRecord
+  before_create :initialize_profile
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  def initialize_profile
+  self.profile = { "email": self.email, "name": self.name, "old": self.old }
+  end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -2,6 +2,19 @@ RailsAdmin.config do |config|
   config.asset_source = :importmap
   ### Popular gems integration
 
+  config.model 'User' do
+    list do
+      field :email
+      field :name
+      field :old
+      field :profile do
+        pretty_value do
+          JSON.pretty_generate(value) if value.present?
+        end
+      end
+    end
+  end
+
   ## == Devise ==
   # config.authenticate_with do
   #   warden.authenticate! scope: :user

--- a/db/migrate/20230905045743_remove_default_from_profile_in_users.rb
+++ b/db/migrate/20230905045743_remove_default_from_profile_in_users.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultFromProfileInUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_column :users, :profile, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_05_043422) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_05_045743) do
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false


### PR DESCRIPTION
1. rails generate migration AddProfileToUsers profile:jsonを実施しprofileカラム作成

2. config/initializers/rails_admin.rbを以下を書き換え
```
RailsAdmin.config do |config|
   config.model 'User' do
     list do
       field :email
       field :name
       field :old
       field :profile do
         pretty_value do
           JSON.pretty_generate(value) if value.present?
         end
       end
     end
   end
 end

```
3. profileがrails_admin側で表示されなかったのでapp/models/user.rbに以下を追加
```
class User < ApplicationRecord
  before_create :initialize_profile

  def initialize_profile
    self.profile = { "email": self.email, "name": self.name, "old": self.old }
  end
end
```

profileカラムの処理は
メアド類登録　→ ||||→　DB登録
|||の部分で入力されたデータを一旦まとめて、一番最初にDB登録する処理をしています。
デメリットとしてeditができません。